### PR TITLE
fix: first-time build errors

### DIFF
--- a/common/Interaction/lasr_dialogflow/CMakeLists.txt
+++ b/common/Interaction/lasr_dialogflow/CMakeLists.txt
@@ -7,10 +7,10 @@ project(lasr_dialogflow)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
 
 ## System dependencies are found with CMake's conventions
-find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
+# find_package(Boost REQUIRED COMPONENTS system)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures

--- a/common/Interaction/lasr_interaction_server/CMakeLists.txt
+++ b/common/Interaction/lasr_interaction_server/CMakeLists.txt
@@ -7,10 +7,10 @@ project(lasr_interaction_server)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
 
 ## System dependencies are found with CMake's conventions
-find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
+# find_package(Boost REQUIRED COMPONENTS system)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures

--- a/common/Perception/face_detection/CMakeLists.txt
+++ b/common/Perception/face_detection/CMakeLists.txt
@@ -11,12 +11,13 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   sensor_msgs
+  message_runtime
+  message_generation
+  lasr_perception_server
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
-
-find_package(lasr_perception_server)
+# find_package(Boost REQUIRED COMPONENTS system)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed

--- a/common/Perception/face_detection/package.xml
+++ b/common/Perception/face_detection/package.xml
@@ -48,13 +48,14 @@
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
- <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <depend>lasr_perception_server</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/common/Perception/lasr_object_detection_yolo/CMakeLists.txt
+++ b/common/Perception/lasr_object_detection_yolo/CMakeLists.txt
@@ -11,12 +11,13 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   sensor_msgs
+  message_runtime
+  message_generation
+  lasr_perception_server
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
-
-find_package(lasr_perception_server)
+# find_package(Boost REQUIRED COMPONENTS system)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed

--- a/common/Perception/lasr_object_detection_yolo/package.xml
+++ b/common/Perception/lasr_object_detection_yolo/package.xml
@@ -55,6 +55,7 @@
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <depend>lasr_perception_server</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/common/Perception/lasr_perception_server/CMakeLists.txt
+++ b/common/Perception/lasr_perception_server/CMakeLists.txt
@@ -11,10 +11,12 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   sensor_msgs
+  message_runtime
+  message_generation
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
+# find_package(Boost REQUIRED COMPONENTS system)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures

--- a/common/Perception/people_detection/recognise_people/CMakeLists.txt
+++ b/common/Perception/people_detection/recognise_people/CMakeLists.txt
@@ -11,12 +11,13 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   sensor_msgs
+  message_runtime
+  message_generation
+  lasr_perception_server
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(catkin REQUIRED COMPONENTS message_generation message_runtime rospy std_msgs)
-
-find_package(lasr_perception_server)
+# find_package(Boost REQUIRED COMPONENTS system)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed

--- a/common/Perception/people_detection/recognise_people/package.xml
+++ b/common/Perception/people_detection/recognise_people/package.xml
@@ -55,6 +55,7 @@
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <depend>lasr_perception_server</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
This PR cleans up dependencies in `CMakeLists.txt` and `package.xml` files specified throughout the project, this fixes the dependency issue where the perception server cannot be found and I've also gone through and made sure everything is defined consistently throughout.