### PR TITLE
feat(yolov8): add `rgb8` encoding support

### DIFF
--- a/common/Perception/lasr_object_detection_yolov8/src/lasr_object_detection_yolov8/yolo.py
+++ b/common/Perception/lasr_object_detection_yolov8/src/lasr_object_detection_yolov8/yolo.py
@@ -14,6 +14,8 @@ def detect(dataset, min_confidence, nms, debug, encoding, width, height, image_d
 
         # BGR => RGB
         img = Image.fromarray(np.array(img)[:,:,::-1])
+    elif encoding == 'rgb8':
+        img = Image.frombytes('RGB', (width, height), image_data, 'raw')
     else:
         raise Exception("Unsupported format.")
     


### PR DESCRIPTION
Ran into this issue when testing with TIAGo.