### PR TITLE
fix/feat/chore: deepface patch and bump

### DIFF
--- a/common/vision/lasr_vision_deepface/examples/relay
+++ b/common/vision/lasr_vision_deepface/examples/relay
@@ -9,7 +9,7 @@ from sensor_msgs.msg import Image
 from lasr_vision_msgs.srv import Recognise, RecogniseRequest
 
 if len(sys.argv) < 3:
-    print('Usage: rosrun lase_recognition relay <source_topic> <dataset>')
+    print("Usage: rosrun lase_recognition relay <source_topic> <dataset>")
     exit()
 
 listen_topic = sys.argv[1]
@@ -17,23 +17,25 @@ dataset = sys.argv[2]
 
 processing = False
 
+
 def detect(image):
     global processing
     processing = True
     rospy.loginfo("Received image message")
 
     try:
-        detect_service = rospy.ServiceProxy('/recognise', Recognise)
+        detect_service = rospy.ServiceProxy("/recognise", Recognise)
         req = RecogniseRequest()
         req.image_raw = image
         req.dataset = dataset
-        req.confidence = 0.5
+        req.confidence = 0.7
         resp = detect_service(req)
         print(resp)
     except rospy.ServiceException as e:
         rospy.logerr("Service call failed: %s" % e)
     finally:
         processing = False
+
 
 def image_callback(image):
     global processing
@@ -43,11 +45,13 @@ def image_callback(image):
     t = threading.Thread(target=detect, args=(image,))
     t.start()
 
+
 def listener():
-    rospy.init_node('image_listener', anonymous=True)
-    rospy.wait_for_service('/recognise')
+    rospy.init_node("image_listener", anonymous=True)
+    rospy.wait_for_service("/recognise")
     rospy.Subscriber(listen_topic, Image, image_callback)
     rospy.spin()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     listener()

--- a/common/vision/lasr_vision_deepface/requirements.in
+++ b/common/vision/lasr_vision_deepface/requirements.in
@@ -1,2 +1,2 @@
-deepface==0.0.81
+deepface==0.0.83
 numpy>=1.2.1

--- a/common/vision/lasr_vision_deepface/requirements.txt
+++ b/common/vision/lasr_vision_deepface/requirements.txt
@@ -6,15 +6,14 @@ cachetools==5.3.2         # via google-auth
 certifi==2023.11.17       # via requests
 charset-normalizer==3.3.2  # via requests
 click==8.1.7              # via flask
-deepface==0.0.81          # via -r requirements.in
-deprecated==1.2.14        # via deepface
+deepface==0.0.83          # via -r requirements.in
 filelock==3.13.1          # via gdown
 fire==0.5.0               # via deepface
 flask==3.0.1              # via deepface
 flatbuffers==23.5.26      # via tensorflow
 gast==0.5.4               # via tensorflow
-gdown==5.0.0              # via deepface, retina-face
-google-auth==2.26.2       # via google-auth-oauthlib, tensorboard
+gdown==5.0.1              # via deepface, retina-face
+google-auth==2.27.0       # via google-auth-oauthlib, tensorboard
 google-auth-oauthlib==1.2.0  # via tensorboard
 google-pasta==0.2.0       # via tensorflow
 grpcio==1.60.0            # via tensorboard, tensorflow
@@ -29,7 +28,7 @@ markdown==3.5.2           # via tensorboard
 markupsafe==2.1.4         # via jinja2, werkzeug
 ml-dtypes==0.2.0          # via tensorflow
 mtcnn==0.1.1              # via deepface
-numpy==1.26.3             # via deepface, h5py, ml-dtypes, opencv-python, opt-einsum, pandas, retina-face, tensorboard, tensorflow
+numpy==1.26.3             # via -r requirements.in, deepface, h5py, ml-dtypes, opencv-python, opt-einsum, pandas, retina-face, tensorboard, tensorflow
 oauthlib==3.2.2           # via requests-oauthlib
 opencv-python==4.9.0.80   # via deepface, mtcnn, retina-face
 opt-einsum==3.3.0         # via tensorflow
@@ -41,10 +40,10 @@ pyasn1==0.5.1             # via pyasn1-modules, rsa
 pyasn1-modules==0.3.0     # via google-auth
 pysocks==1.7.1            # via requests
 python-dateutil==2.8.2    # via pandas
-pytz==2023.3.post1        # via pandas
+pytz==2023.4              # via pandas
 requests[socks]==2.31.0   # via gdown, requests-oauthlib, tensorboard
 requests-oauthlib==1.3.1  # via google-auth-oauthlib
-retina-face==0.0.13       # via deepface
+retina-face==0.0.14       # via deepface
 rsa==4.9                  # via google-auth
 six==1.16.0               # via astunparse, fire, google-pasta, python-dateutil, tensorboard, tensorflow
 soupsieve==2.5            # via beautifulsoup4
@@ -60,7 +59,7 @@ tzdata==2023.4            # via pandas
 urllib3==2.1.0            # via requests
 werkzeug==3.0.1           # via flask, tensorboard
 wheel==0.42.0             # via astunparse
-wrapt==1.14.1             # via deprecated, tensorflow
+wrapt==1.14.1             # via tensorflow
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/common/vision/lasr_vision_deepface/scripts/create_dataset
+++ b/common/vision/lasr_vision_deepface/scripts/create_dataset
@@ -8,7 +8,7 @@ if len(sys.argv) < 3:
         "usage: rosrun lasr_vision_deepface create_dataset.py <topic> <dataset> <name> [size=50]"
     )
     exit(0)
-print(sys.argv)
+
 topic = sys.argv[1]
 dataset = sys.argv[2]
 name = sys.argv[3]

--- a/common/vision/lasr_vision_deepface/scripts/create_dataset
+++ b/common/vision/lasr_vision_deepface/scripts/create_dataset
@@ -5,15 +5,16 @@ import lasr_vision_deepface as face_recognition
 
 if len(sys.argv) < 3:
     print(
-        "usage: rosrun lasr_vision_deepface create_dataset.py <dataset> <name> [size=50]"
+        "usage: rosrun lasr_vision_deepface create_dataset.py <topic> <dataset> <name> [size=50]"
     )
     exit(0)
+print(sys.argv)
+topic = sys.argv[1]
+dataset = sys.argv[2]
+name = sys.argv[3]
 
-dataset = sys.argv[1]
-name = sys.argv[2]
-
-if len(sys.argv) > 3:
-    size = sys.argv[3]
+if len(sys.argv) > 4:
+    size = int(sys.argv[4])
 else:
     size = 50
 
@@ -35,7 +36,7 @@ rospy.init_node("create_dataset")
 rospy.loginfo(f"Taking {size} pictures of {name} and saving to {DATASET_PATH}")
 
 for i in range(size):
-    img_msg = rospy.wait_for_message("/xtion/rgb/image_raw", Image)
+    img_msg = rospy.wait_for_message(topic, Image)
     cv_im = cv2_img.msg_to_cv2_img(img_msg)
     face_cropped_cv_im = face_recognition.detect_face(cv_im)
     if face_cropped_cv_im is None:

--- a/common/vision/lasr_vision_deepface/src/lasr_vision_deepface/deepface.py
+++ b/common/vision/lasr_vision_deepface/src/lasr_vision_deepface/deepface.py
@@ -47,7 +47,7 @@ def detect(
             cv_im,
             os.path.join(DATASET_ROOT, request.dataset),
             enforce_detection=True,
-            silent=False,
+            silent=True,
             detector_backend="mtcnn",
             threshold=request.confidence,
         )

--- a/common/vision/lasr_vision_deepface/src/lasr_vision_deepface/deepface.py
+++ b/common/vision/lasr_vision_deepface/src/lasr_vision_deepface/deepface.py
@@ -34,16 +34,20 @@ def detect(
     rospy.loginfo("Decoding")
     cv_im = cv2_img.msg_to_cv2_img(request.image_raw)
 
+    response = RecogniseResponse()
+
     # Run inference
     rospy.loginfo("Running inference")
-    result = DeepFace.find(
-        cv_im,
-        os.path.join(DATASET_ROOT, request.dataset),
-        enforce_detection=False,
-        silent=True,
-    )
-
-    response = RecogniseResponse()
+    try:
+        result = DeepFace.find(
+            cv_im,
+            os.path.join(DATASET_ROOT, request.dataset),
+            enforce_detection=True,
+            silent=True,
+            detector_backend="mtcnn",
+        )
+    except ValueError:
+        return response
 
     for row in result:
         if row.empty:

--- a/common/vision/lasr_vision_msgs/srv/Recognise.srv
+++ b/common/vision/lasr_vision_msgs/srv/Recognise.srv
@@ -4,7 +4,7 @@ sensor_msgs/Image image_raw
 # Dataset to use
 string dataset
 
-# How certain the detection should be to include
+# Confidence threshold for filtering detections
 float32 confidence
 
 ---


### PR DESCRIPTION
This PR achieves a few things:
- Fixes some annoying nuances with dataset creation.
- Allows dataset creation to listen on a specific topic.
- Bump `deepface` version.
- Utilise new `threshold` option for filtering out low confidence detections.
- Workaround for a dumb bug (that is not our fault), that causes the entire frame to be outputted as a detection when no faces are present.